### PR TITLE
Updating swagger to add API Tokens 

### DIFF
--- a/api-swagger-patched.yaml
+++ b/api-swagger-patched.yaml
@@ -42,6 +42,32 @@ definitions:
       data:
         $ref: "#/definitions/HealthCheck"
 
+  Provider:
+    type: string
+    x-ms-enum:
+      name: "Provider"
+    enum:
+      - manual
+      - bb
+      - bbe
+      - gh
+      - ghe
+      - gl
+      - gle
+
+  AccountProvider:
+    type: string
+    x-ms-enum:
+      name: "AccountProvider"
+    enum: &accountProviderEnum
+      - github-enterprise
+      - github
+      - google
+      - bitbucket
+      - bitbucket-server
+      - gitlab
+      - gitlab-enterprise
+
   PaginationInfo:
     type: object
     properties:
@@ -179,26 +205,27 @@ definitions:
         items:
           $ref: "#/definitions/Integration"
 
-  Provider:
-    type: string
-    enum:
-      - manual
-      - bb
-      - bbe
-      - gh
-      - ghe
-      - gl
-      - gle
+  ApiToken:
+    type: object
+    required:
+      - id
+      - token
+    properties:
+      id:
+        type: integer
+        format: int64
+      token:
+        type: string
 
-  AccountProvider:
-    type: string
-    enum: &accountProviderEnum
-      - github-enterprise
-      - github
-      - google
-      - bitbucket
-      - gitlab
-      - bitbucket-server
+  ApiTokenListResponse:
+    type: object
+    required:
+      - data
+    properties:
+      data:
+        type: array
+        items:
+          $ref: "#/definitions/ApiToken"
 
   JoinMode:
     type: string
@@ -253,15 +280,16 @@ definitions:
       - $ref: "#/definitions/ApiError"
 
 parameters:
-  cursorParam: &cursorParam
+  cursorParam:
     in: query
     name: cursor
     required: false
     type: string
-    description: Cursor to list elements after.
+    description: "Cursor to list elements after."
     x-example: "Yms345gh=="
+    x-ms-parameter-location: 'method'
 
-  limitParam: &limitParam
+  limitParam:
     in: query
     name: limit
     required: false
@@ -270,17 +298,31 @@ parameters:
     minimum: 1
     maximum: 100
     default: 100
-    description: Number of items to return.
+    description: "Number of items to return."
     x-example: 20
+    x-ms-parameter-location: 'method'
 
-  accountProviderParam: &accountProviderParam
+  accountProviderParam:
     in: path
     name: provider
     description: "Account Provider"
     required: true
     type: string
     enum: *accountProviderEnum
+    x-ms-enum:
+      name: "AccountProvider"
     x-example: github
+    x-ms-parameter-location: 'method'
+
+  tokenIdParam:
+    in: path
+    name: tokenId
+    description: "Token ID"
+    required: true
+    type: integer
+    format: int64
+    x-example: 30
+    x-ms-parameter-location: 'method'
 
 paths:
   /user:
@@ -295,11 +337,6 @@ paths:
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/UserResponse'
-        '401':
-          description: 'Unauthorized'
-          x-ms-error-response: true
-          schema:
-            $ref: '#/definitions/ApiError'
         '500':
           description: 'Internal Server Error'
           x-ms-error-response: true
@@ -320,11 +357,6 @@ paths:
       responses:
         '204':
           description: 'Successful operation'
-        '401':
-          description: 'Unauthorized'
-          x-ms-error-response: true
-          schema:
-            $ref: '#/definitions/ApiError'
         '500':
           description: 'Internal Server Error'
           x-ms-error-response: true
@@ -345,17 +377,11 @@ paths:
           description: 'Successful operation'
           schema:
             $ref: '#/definitions/UserResponse'
-        '401':
-          description: 'Unauthorized'
-          x-ms-error-response: true
-          schema:
-            $ref: '#/definitions/ApiError'
         '500':
           description: 'Internal Server Error'
           x-ms-error-response: true
           schema:
             $ref: '#/definitions/ApiError'
-
 
   /user/orgs:
     get:
@@ -365,8 +391,8 @@ paths:
       description: List organizations for the authenticated user
       operationId: listUserOrganizations
       parameters:
-        - *cursorParam
-        - *limitParam
+        - $ref: '#/parameters/cursorParam'
+        - $ref: '#/parameters/limitParam'
       responses:
         '200':
           description: 'Successful operation'
@@ -374,11 +400,6 @@ paths:
               $ref: '#/definitions/OrganizationListResponse'
         '400':
           description: 'Bad Request'
-          x-ms-error-response: true
-          schema:
-            $ref: '#/definitions/ApiError'
-        '401':
-          description: 'Unauthorized'
           x-ms-error-response: true
           schema:
             $ref: '#/definitions/ApiError'
@@ -396,8 +417,8 @@ paths:
       description: List integrations for the authenticated user
       operationId: listUserIntegrations
       parameters:
-        - *cursorParam
-        - *limitParam
+        - $ref: '#/parameters/cursorParam'
+        - $ref: '#/parameters/limitParam'
       responses:
         '200':
           description: 'Successful operation'
@@ -425,17 +446,12 @@ paths:
         - account
       operationId: deleteIntegration
       parameters:
-        - *accountProviderParam
+        - $ref: '#/parameters/accountProviderParam'
       responses:
         '204':
           description: 'Successful operation'
         '400':
           description: 'Bad Request'
-          x-ms-error-response: true
-          schema:
-            $ref: '#/definitions/ApiError'
-        '401':
-          description: 'Unauthorized'
           x-ms-error-response: true
           schema:
             $ref: '#/definitions/ApiError'
@@ -446,6 +462,58 @@ paths:
             $ref: '#/definitions/ApiError'
         '500':
           description: 'Internal Server Error'
+          x-ms-error-response: true
+          schema:
+            $ref: '#/definitions/ApiError'
+
+  /user/tokens:
+    get:
+      tags:
+        - account
+      summary: Get the authenticated user's API Tokens
+      description: Get the authenticated user's API Tokens
+      operationId: getUserApiTokens
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/ApiTokenListResponse'
+        '500':
+          description: 'Internal Server Error'
+          x-ms-error-response: true
+          schema:
+            $ref: '#/definitions/ApiError'
+    post:
+      tags:
+        - account
+      summary: Create an API Token for the authenticated user
+      description: Create an API Token for the authenticated user
+      operationId: createUserApiToken
+      responses:
+        '200':
+          description: 'Successful operation'
+          schema:
+            $ref: '#/definitions/ApiToken'
+        '500':
+          description: 'Internal Server Error'
+          x-ms-error-response: true
+          schema:
+            $ref: '#/definitions/ApiError'
+
+  /user/tokens/{tokenId}:
+    delete:
+      tags:
+        - account
+      summary: Delete an API Token of the authenticated user
+      description: Delete an API Token of the authenticated user
+      operationId: deleteUserApiToken
+      parameters:
+        - $ref: '#/parameters/tokenIdParam'
+      responses:
+        '204':
+          description: 'Successful operation'
+        '404':
+          description: 'Not Found'
           x-ms-error-response: true
           schema:
             $ref: '#/definitions/ApiError'

--- a/api-swagger-patched.yaml
+++ b/api-swagger-patched.yaml
@@ -105,8 +105,8 @@ definitions:
       isActive:
         type: boolean
       created:
-        type: integer
-        format: int64
+        type: string
+        format: date-time
         x-scala-type: java.time.Instant
     example:
       username: "FooBar"
@@ -150,8 +150,8 @@ definitions:
       avatar:
         type: string
       createdAt:
-        type: integer
-        format: int64
+        type: string
+        format: date-time
         x-scala-type: java.time.Instant
       provider:
         $ref: '#/definitions/Provider'
@@ -186,8 +186,8 @@ definitions:
       provider:
         $ref: "#/definitions/AccountProvider"
       lastTimeAuthenticated:
-        type: integer
-        format: int64
+        type: string
+        format: date-time
         x-scala-type: java.time.Instant
     example:
       name: "FooOrganization"

--- a/api-swagger-patched.yaml
+++ b/api-swagger-patched.yaml
@@ -79,7 +79,8 @@ definitions:
       isActive:
         type: boolean
       created:
-        type: string
+        type: integer
+        format: int64
         x-scala-type: java.time.Instant
     example:
       username: "FooBar"
@@ -123,7 +124,8 @@ definitions:
       avatar:
         type: string
       createdAt:
-        type: string
+        type: integer
+        format: int64
         x-scala-type: java.time.Instant
       provider:
         $ref: '#/definitions/Provider'
@@ -158,7 +160,8 @@ definitions:
       provider:
         $ref: "#/definitions/AccountProvider"
       lastTimeAuthenticated:
-        type: string
+        type: integer
+        format: int64
         x-scala-type: java.time.Instant
     example:
       name: "FooOrganization"
@@ -270,14 +273,14 @@ parameters:
     description: Number of items to return.
     x-example: 20
 
-  # accountProviderParam: &accountProviderParam
-  #   in: path
-  #   name: provider
-  #   description: "Account Provider"
-  #   required: true
-  #   type: string
-  #   enum: *accountProviderEnum
-  #   x-example: github
+  accountProviderParam: &accountProviderParam
+    in: path
+    name: provider
+    description: "Account Provider"
+    required: true
+    type: string
+    enum: *accountProviderEnum
+    x-example: github
 
 paths:
   /user:
@@ -422,13 +425,7 @@ paths:
         - account
       operationId: deleteIntegration
       parameters:
-        - in: path
-          name: provider
-          description: "Account Provider"
-          required: true
-          type: string
-          enum: *accountProviderEnum
-          x-example: github
+        - *accountProviderParam
       responses:
         '204':
           description: 'Successful operation'

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "remark-preset-lint-recommended": "^3.0.3",
     "typescript": "^3.7.5"
   },
-  "apiVersion": "8.5.1",
+  "apiVersion": "8.17.0",
   "remarkConfig": {
     "plugins": [
       "remark-preset-lint-recommended"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "check-types": "tsc --noEmit",
     "check-types:watch": "npm run check-types -- --watch",
     "fetch-api": "curl https://dl.bintray.com/codacy/Binaries/$npm_package_apiVersion/swagger.yaml -o api-swagger.yaml",
-    "generate": "autorest --typescript --model-date-time-as-string=false --input-file=./api-swagger-patched.yaml --output-folder=./",
+    "generate": "autorest --typescript --model-date-time-as-string=true --input-file=./api-swagger-patched.yaml --output-folder=./",
     "lint-md": "remark .",
     "prepare": "npm run fetch-api && npm run generate"
   },


### PR DESCRIPTION
Plus fixing some issues with the autorest generated models and signatures.

Things to note:

- Added `x-ms-parameter-location: 'method'` to parameters. This is needed so autorest doesn't place these as an option on the API client constructor.

- Reduced the YAML aliases (`&`+`*` referencing) since these have implications on duplication of types. 
  - When possible we should use `$ref`, unless we need to use overrides (YAML merge keys)
  - Kept the YAML alias on `accountProviderParam` since swagger does not support `$ref` on parameter objects.

- Added `x-ms-enum: { name: 'AccountProvider' }`. Re-usable definitions that have enums produce duplicate type definitions on autorest. 

- Changed timestamps to use string with date-time format. Changed autorest param to not parse date-times since it parses to JS Date object. Since I do not know how they parse it or if they pass it directly to the constructor I'd rather do the building ourselves by using moment or similar.