### PR TITLE
Update new location of our public API specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "tsc",
     "check-types": "tsc --noEmit",
     "check-types:watch": "npm run check-types -- --watch",
-    "fetch-api": "curl https://dl.bintray.com/codacy/Binaries/$npm_package_apiVersion/swagger.yaml -o api-swagger.yaml",
+    "fetch-api": "curl https://dl.bintray.com/codacy/api/codacy-api/$npm_package_apiVersion/apiv3.yaml -o api-swagger.yaml",
     "generate": "autorest --typescript --model-date-time-as-string=true --input-file=./api-swagger.yaml --output-folder=./",
     "lint-md": "remark .",
     "prepare": "npm run fetch-api && npm run generate"


### PR DESCRIPTION
Starting at 18.4.0 website swagger file is published under apiv3.yaml at https://dl.bintray.com/codacy/api/codacy-api/
(Feel free to check https://bitbucket.org/qamine/codacy-seed/pull-requests/39/update-the-path-to-publish-the-swagger if you guys want to know more about why this change is happening)

* This PR only adds the commit for the location, please consider if you guys also want to change the name of the output to apiv3.yaml or if it should stay the same.

* Also please bump to >18.4.0 since it is the first version available there 