### PR TITLE
fix: Avoid pushing `latest` tag from branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,11 @@ jobs:
             # Update version in packages to publish
             npm version --no-git-tag-version --no-commit-hooks "$(cat .version)"
             # Publish package versions to npmjs.org
-            npm publish
+            if [ "$CIRCLE_BRANCH" = "master" ]; then
+              npm publish
+            else
+              npm publish --tag unstable
+            fi
 
 workflows:
   compile_deploy:


### PR DESCRIPTION
If you remove the master branch filter, maybe to test some changes, then it pushes the `latest` tag.
This will make it tag an `unstable` version instead.