### PR TITLE
clean: add Codacy origin header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -176,6 +176,8 @@ class ApiErrorHandlerPolicy extends BaseRequestPolicy {
     let body
     try {
       webResource.headers.set('Csrf-Token', 'nocheck')
+      webResource.headers.set('X-Codacy-Origin', 'frontend')
+
       result = await this._nextPolicy.sendRequest(webResource)
       body = result.parsedBody
     } catch (err) {


### PR DESCRIPTION
Adding header for all requests to identify the origin of the request